### PR TITLE
There are cases where mutex deadlocks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,6 @@ matrix:
         - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
 before_install:
     - eval "${MATRIX_EVAL}"
-    - sudo apt update -qqy
     - sudo apt install sudo netcat
     - curl -fsSL https://repo.stns.jp/scripts/apt-repo.sh | sh
     - sudo apt install -qqy stns-v2

--- a/stns.c
+++ b/stns.c
@@ -348,7 +348,8 @@ static void *delete_cache_files(void *data)
   char dir[MAXBUF];
   sprintf(dir, "%s/%d", c->cache_dir, geteuid());
 
-  pthread_mutex_lock(&delete_mutex);
+  if (pthread_mutex_trylock(&delete_mutex) != 0)
+    return NULL;
   if ((dp = opendir(dir)) == NULL) {
     syslog(LOG_ERR, "%s(stns)[L%d] cannot open %s: %s", __func__, __LINE__, dir, strerror(errno));
     pthread_mutex_unlock(&delete_mutex);
@@ -411,7 +412,8 @@ int stns_request(stns_conf_t *c, char *path, stns_response_t *res)
           return CURLE_HTTP_RETURNED_ERROR;
         }
 
-        pthread_mutex_lock(&delete_mutex);
+        if (pthread_mutex_trylock(&delete_mutex) != 0)
+          goto request;
         if (!stns_import_file(fpath, res)) {
           pthread_mutex_unlock(&delete_mutex);
           goto request;
@@ -454,9 +456,10 @@ request:
 
   if (c->cache) {
     pthread_join(pthread, NULL);
-    pthread_mutex_lock(&delete_mutex);
-    stns_export_file(dpath, fpath, res->data);
-    pthread_mutex_unlock(&delete_mutex);
+    if (pthread_mutex_trylock(&delete_mutex) == 0) {
+      stns_export_file(dpath, fpath, res->data);
+      pthread_mutex_unlock(&delete_mutex);
+    }
   }
   return result;
 }

--- a/stns.h
+++ b/stns.h
@@ -27,6 +27,8 @@
 #define MAXBUF 1024
 #define STNS_LOCK_FILE "/var/tmp/.stns.lock"
 #define STNS_HTTP_NOTFOUND 404L
+#define STNS_LOCK_RETRY 3
+#define STNS_LOCK_INTERVAL_MSEC 10
 
 typedef struct stns_response_t stns_response_t;
 struct stns_response_t {
@@ -66,7 +68,7 @@ extern int stns_user_highest_query_available(int);
 extern int stns_user_lowest_query_available(int);
 extern int stns_group_highest_query_available(int);
 extern int stns_group_lowest_query_available(int);
-
+extern int pthread_mutex_retrylock(pthread_mutex_t *mutex);
 extern void set_user_highest_id(int);
 extern void set_user_lowest_id(int);
 extern void set_group_highest_id(int);
@@ -144,7 +146,6 @@ extern void set_group_lowest_id(int);
                                                                                                                        \
   if (buflen < name##_length) {                                                                                        \
     *errnop = ERANGE;                                                                                                  \
-    pthread_mutex_unlock(&type##ent_mutex);                                                                            \
     return NSS_STATUS_TRYAGAIN;                                                                                        \
   }                                                                                                                    \
                                                                                                                        \
@@ -156,7 +157,7 @@ extern void set_group_lowest_id(int);
 #define STNS_SET_ENTRIES(type, ltype, resource, query)                                                                 \
   enum nss_status inner_nss_stns_set##type##ent(char *data, stns_conf_t *c)                                            \
   {                                                                                                                    \
-    if (pthread_mutex_trylock(&type##ent_mutex) != 0)                                                                  \
+    if (pthread_mutex_retrylock(&type##ent_mutex) != 0)                                                                \
       return NSS_STATUS_UNAVAIL;                                                                                       \
                                                                                                                        \
     entries          = NULL;                                                                                           \
@@ -198,7 +199,7 @@ extern void set_group_lowest_id(int);
                                                                                                                        \
   enum nss_status _nss_stns_end##type##ent(void)                                                                       \
   {                                                                                                                    \
-    if (pthread_mutex_trylock(&type##ent_mutex) != 0)                                                                  \
+    if (pthread_mutex_retrylock(&type##ent_mutex) != 0)                                                                \
       return NSS_STATUS_UNAVAIL;                                                                                       \
     entry_idx = 0;                                                                                                     \
     if (entry_idx != 0)                                                                                                \
@@ -211,9 +212,7 @@ extern void set_group_lowest_id(int);
   enum nss_status inner_nss_stns_get##type##ent_r(stns_conf_t *c, struct resource *rbuf, char *buf, size_t buflen,     \
                                                   int *errnop)                                                         \
   {                                                                                                                    \
-    enum nss_status ret = NSS_STATUS_SUCCESS;                                                                          \
-    if (pthread_mutex_trylock(&type##ent_mutex) != 0)                                                                  \
-      return NSS_STATUS_UNAVAIL;                                                                                       \
+    enum nss_status ret       = NSS_STATUS_SUCCESS;                                                                    \
     JSON_Array *array_entries = json_value_get_array(entries);                                                         \
                                                                                                                        \
     if (array_entries == NULL) {                                                                                       \
@@ -221,13 +220,11 @@ extern void set_group_lowest_id(int);
     }                                                                                                                  \
                                                                                                                        \
     if (ret != NSS_STATUS_SUCCESS) {                                                                                   \
-      pthread_mutex_unlock(&type##ent_mutex);                                                                          \
       return ret;                                                                                                      \
     }                                                                                                                  \
                                                                                                                        \
     if (entry_idx >= json_array_get_count(array_entries)) {                                                            \
       *errnop = ENOENT;                                                                                                \
-      pthread_mutex_unlock(&type##ent_mutex);                                                                          \
       return NSS_STATUS_NOTFOUND;                                                                                      \
     }                                                                                                                  \
                                                                                                                        \
@@ -235,7 +232,6 @@ extern void set_group_lowest_id(int);
                                                                                                                        \
     ltype##_ENSURE(user);                                                                                              \
     entry_idx++;                                                                                                       \
-    pthread_mutex_unlock(&type##ent_mutex);                                                                            \
     return NSS_STATUS_SUCCESS;                                                                                         \
   }                                                                                                                    \
                                                                                                                        \
@@ -243,7 +239,10 @@ extern void set_group_lowest_id(int);
   {                                                                                                                    \
     stns_conf_t c;                                                                                                     \
     stns_load_config(STNS_CONFIG_FILE, &c);                                                                            \
+    if (pthread_mutex_retrylock(&type##ent_mutex) != 0)                                                                \
+      return NSS_STATUS_UNAVAIL;                                                                                       \
     int result = inner_nss_stns_get##type##ent_r(&c, rbuf, buf, buflen, errnop);                                       \
+    pthread_mutex_unlock(&type##ent_mutex);                                                                            \
     stns_unload_config(&c);                                                                                            \
     return result;                                                                                                     \
   }
@@ -251,7 +250,7 @@ extern void set_group_lowest_id(int);
 #define SET_GET_HIGH_LOW_ID(highest_or_lowest, user_or_group)                                                          \
   void set_##user_or_group##_##highest_or_lowest##_id(int id)                                                          \
   {                                                                                                                    \
-    if (pthread_mutex_trylock(&user_or_group##_mutex) != 0)                                                            \
+    if (pthread_mutex_retrylock(&user_or_group##_mutex) != 0)                                                          \
       return;                                                                                                          \
     highest_or_lowest##_##user_or_group##_id = id;                                                                     \
     pthread_mutex_unlock(&user_or_group##_mutex);                                                                      \
@@ -259,7 +258,7 @@ extern void set_group_lowest_id(int);
   int get_##user_or_group##_##highest_or_lowest##_id(void)                                                             \
   {                                                                                                                    \
     int r;                                                                                                             \
-    if (pthread_mutex_trylock(&user_or_group##_mutex) != 0)                                                            \
+    if (pthread_mutex_retrylock(&user_or_group##_mutex) != 0)                                                          \
       return 0;                                                                                                        \
     r = highest_or_lowest##_##user_or_group##_id;                                                                      \
     pthread_mutex_unlock(&user_or_group##_mutex);                                                                      \


### PR DESCRIPTION
we have found a case where pthread_mutex is deadlocked by nscd, i add return an error at deadlock.
thanks: @tsrubee