### PR TITLE
Call header_handler even if server returned 4xx response

### DIFF
--- a/stns.c
+++ b/stns.c
@@ -294,6 +294,7 @@ static CURLcode inner_http_request(stns_conf_t *c, char *path, stns_response_t *
     syslog(LOG_ERR, "%s(stns)[L%d] http request failed: %s", __func__, __LINE__, curl_easy_strerror(result));
     res->data = NULL;
     res->size = 0;
+    res->status_code = code;
     result = CURLE_HTTP_RETURNED_ERROR;
   }
 


### PR DESCRIPTION
It seems to ignore `header_handler` when `CURLOPT_FAILONERROR` is enabled, so `highest(or lowest)_user_id` is't going to be stored if the UID not found.

It cause trouble such as when execute `useradd -r systemuser`.
In this case, `useradd` tries to resolve 1 to 1000 uid. and all of them should not be found. As a result, 1000 http requests are made.
In my environment, `useradd -r` takes 4,5 minutes.

I changed `inner_http_request` func:
- disable `CURLOPT_FAILONERROR`
- return `CURLE_HTTP_RETURNED_ERROR` manually when 4xx response returned by server.