### PR TITLE
Need daemon-reload after rewriting service file

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -18,8 +18,7 @@ set -e
 # the debian-policy package
 
 sed -i "s/^IPAddressDeny=any/#IPAddressDeny=any/" /lib/systemd/system/systemd-logind.service || true
-systemctl daemon-reload
-systemctl status systemd-logind && systemctl restart systemd-logind
+systemctl status systemd-logind && systemctl daemon-reload && systemctl restart systemd-logind
 
 case "$1" in
     configure)

--- a/debian/postinst
+++ b/debian/postinst
@@ -18,6 +18,7 @@ set -e
 # the debian-policy package
 
 sed -i "s/^IPAddressDeny=any/#IPAddressDeny=any/" /lib/systemd/system/systemd-logind.service || true
+systemctl daemon-reload
 systemctl status systemd-logind && systemctl restart systemd-logind
 
 case "$1" in

--- a/rpm/stns.spec
+++ b/rpm/stns.spec
@@ -42,6 +42,7 @@ install -m 644 stns.conf.example %{buildroot}%{_sysconfdir}/stns/client/stns.con
 
 %post
 sed -i "s/^IPAddressDeny=any/#IPAddressDeny=any/" /lib/systemd/system/systemd-logind.service || true
+systemctl daemon-reload
 systemctl status systemd-logind && systemctl restart systemd-logind
 
 %preun

--- a/rpm/stns.spec
+++ b/rpm/stns.spec
@@ -42,8 +42,7 @@ install -m 644 stns.conf.example %{buildroot}%{_sysconfdir}/stns/client/stns.con
 
 %post
 sed -i "s/^IPAddressDeny=any/#IPAddressDeny=any/" /lib/systemd/system/systemd-logind.service || true
-systemctl daemon-reload
-systemctl status systemd-logind && systemctl restart systemd-logind
+systemctl status systemd-logind && systemctl daemon-reload && systemctl restart systemd-logind
 
 %preun
 


### PR DESCRIPTION
From v2.3.2, `systemd-logind.service` is rewritten during post installation. However, the restart fails because daemon-reload is not running, so add the command.