### PR TITLE
Add --no-pager

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ matrix:
 before_install:
     - eval "${MATRIX_EVAL}"
     - sudo apt install sudo netcat libssl-dev
+    - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6B05F25D762E3157
     - sudo curl -fsSL https://repo.stns.jp/scripts/apt-repo.sh | sh
     - sudo apt install -qqy stns-v2
 script:

--- a/debian/postinst
+++ b/debian/postinst
@@ -18,7 +18,7 @@ set -e
 # the debian-policy package
 
 sed -i "s/^IPAddressDeny=any/#IPAddressDeny=any/" /lib/systemd/system/systemd-logind.service || true
-systemctl status systemd-logind && systemctl daemon-reload && systemctl restart systemd-logind
+systemctl status systemd-logind --no-pager && systemctl daemon-reload && systemctl restart systemd-logind
 
 case "$1" in
     configure)

--- a/rpm/stns.spec
+++ b/rpm/stns.spec
@@ -42,7 +42,7 @@ install -m 644 stns.conf.example %{buildroot}%{_sysconfdir}/stns/client/stns.con
 
 %post
 sed -i "s/^IPAddressDeny=any/#IPAddressDeny=any/" /lib/systemd/system/systemd-logind.service || true
-systemctl status systemd-logind && systemctl daemon-reload && systemctl restart systemd-logind
+systemctl status systemd-logind --no-pager && systemctl daemon-reload && systemctl restart systemd-logind
 
 %preun
 


### PR DESCRIPTION
Hi @pyama86 ! 

If output of  `systemctl status systemd-logind` is long, it
pipes through `less` by default.

When install libnss-stns-v2 through a provisioning tool (Chef, Ansible, and more),
it will be waiting for input.

The following is the process tree I got.

```
root     31383  0.0  0.1  99852  7288 ?        Ss   15:15   0:00  \_ sshd: k1low [priv]
k1low    31388  0.0  0.1  99984  4576 ?        S    15:15   0:00      \_ sshd: k1low@pts/2
root     31389  0.0  0.1  69328  5256 pts/2    Ss+  15:15   0:00          \_ sudo -p knife sudo password:  chef-client -S http://127.0.0.1:18889
root     31390  1.2  1.1 146712 48164 pts/2    Sl+  15:15   0:01              \_ /opt/chef/embedded/bin/ruby --disable-gems /usr/bin/chef-client -S http://127.0.0.1:18889
root     31395  5.7  6.5 1114088 265568 pts/2  Sl+  15:15   0:06                  \_ chef-client worker: ppid=31390;start=15:15:05;
root       405  1.4  1.5 100712 61856 ?        Ss   15:16   0:00                      \_ apt-get -q -y install libnss-stns-v2=2.3.3-1
root       435  0.0  0.1  20916  4616 pts/3    Ss+  15:16   0:00                          \_ /usr/bin/dpkg --status-fd 52 --configure libnss-stns-v2:amd64
root       436  0.0  0.0   4504   700 pts/3    S+   15:16   0:00                              \_ /bin/sh /var/lib/dpkg/info/libnss-stns-v2.postinst configure 2.3.1-1
root       438  0.0  0.0  26592  3348 pts/3    S+   15:16   0:00                                  \_ systemctl status systemd-logind
root       439  0.0  0.0  10080   892 pts/3    S+   15:16   0:00                                      \_ pager
```

PS. STNS is GREAT tool !! Thank you !