### PR TITLE
cache dir with sticky bit

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -23,7 +23,7 @@ systemctl status systemd-logind --no-pager && systemctl daemon-reload && systemc
 case "$1" in
     configure)
         mkdir -p /var/cache/stns
-        chmod 777 /var/cache/stns
+        chmod 1777 /var/cache/stns
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)

--- a/rpm/stns.spec
+++ b/rpm/stns.spec
@@ -33,7 +33,7 @@ make
 mkdir -p %{buildroot}/usr/{lib64,bin}
 mkdir -p %{buildroot}%{_sysconfdir}
 make PREFIX=%{buildroot}/usr install
-install -d -m 0777 %{buildroot}/var/cache/stns
+install -d -m 1777 %{buildroot}/var/cache/stns
 install -d -m 0744 %{buildroot}%{_sysconfdir}/stns/client/
 install -m 644 stns.conf.example %{buildroot}%{_sysconfdir}/stns/client/stns.conf
 


### PR DESCRIPTION
STNS's cache dir is created with sticky bit.

https://github.com/STNS/libnss/blob/30ae62c117563aba68a5ca8629140e5c9adf35ee/stns.c#L48-L52

so I modify deb & rpm settings.