### PR TITLE
Retry inner_http_request when CURLINFO_RESPONSE_CODE is 0.

### DIFF
--- a/stns.c
+++ b/stns.c
@@ -561,6 +561,7 @@ request:
           break;
         }
         sleep(1);
+        syslog(LOG_NOTICE, "%s(stns)[L%d] %d retries remaining", __func__, __LINE__, retry_count);
         result = inner_http_request(c, path, res);
         retry_count--;
       } else {

--- a/stns.c
+++ b/stns.c
@@ -344,7 +344,8 @@ static CURLcode inner_http_request(stns_conf_t *c, char *path, stns_response_t *
     res->data        = NULL;
     res->size        = 0;
     res->status_code = code;
-    result           = CURLE_HTTP_RETURNED_ERROR;
+    if (code != 0)
+      result = CURLE_HTTP_RETURNED_ERROR;
   }
 
 #ifdef DEBUG


### PR DESCRIPTION
I want to retry inner_http_request when CURLINFO_RESPONSE_CODE(code) is 0.
If the result of inner_http_request is CURLE_HTTP_RETURNED_ERROR, it will not be retried.

e.g, the following is an error with `code:0`.

- inner_http_request(stns)[L342] http request failed: Timeout was reached code:0
- inner_http_request(stns)[L342] http request failed: Couldn't connect to server code:0
- inner_http_request(stns)[L342] http request failed: SSL connect error code:0