### PR TITLE
fix deb target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,6 +237,7 @@ deb: source_for_deb ## Packaging for DEB
 		debuild -e DIST=$(DIST) -uc -us
 	cd $(STNS_DIR) && \
 		find . -name "*.deb" | sed -e 's/\(\(.*libnss-stns-v2.*\).deb\)/mv \1 \2.$(DIST).deb/g' | sh && \
+		mkdir -p /stns/builds && \
 		cp *.deb /stns/builds
 	rm -rf $(STNS_DIR)
 


### PR DESCRIPTION
Copying of Debian packages failed because the builds directory is missing.
Added creating the builds directory.

```
# docker-compose up nss_debian11
nss_debian11_1  | Finished running lintian.
nss_debian11_1  | cd /stns/tmp/bullseye/stns && \
nss_debian11_1  |       find . -name "*.deb" | sed -e 's/\(\(.*libnss-stns-v2.*\).deb\)/mv \1 \2.bullseye.deb/g' | sh && \
nss_debian11_1  |       cp *.deb /stns/builds
nss_debian11_1  | cp: target '/stns/builds' is not a directory
nss_debian11_1  | make: *** [Makefile:231: deb] Error 1
libnss_nss_debian11_1 exited with code 2
```