### PR TITLE
Allow uppercase letters in usernames and group names

### DIFF
--- a/stns.c
+++ b/stns.c
@@ -8,6 +8,7 @@
 #include <unistd.h>
 #include <dirent.h>
 #include <fcntl.h>
+#include <ctype.h>
 pthread_mutex_t user_mutex  = PTHREAD_MUTEX_INITIALIZER;
 pthread_mutex_t group_mutex = PTHREAD_MUTEX_INITIALIZER;
 int highest_user_id         = 0;
@@ -714,14 +715,13 @@ int is_valid_username(const char *username)
   }
 
   // The first character must be a alpha.
-  if (!(username[0] >= 'a' && username[0] <= 'z')) {
+  if (!isalpha(username[0])) {
     return 1;
   }
 
   // The rest characters can be only alpha, digit, dash or underscore.
   for (size_t i = 1; i < len; i++) {
-    if (!(username[i] >= 'a' && username[i] <= 'z') && !(username[i] >= '0' && username[i] <= '9') &&
-        username[i] != '-' && username[i] != '_') {
+    if (!isalnum(username[i]) && username[i] != '-' && username[i] != '_') {
       return 1;
     }
   }
@@ -742,14 +742,13 @@ int is_valid_groupname(const char *groupname)
   }
 
   // The first character must be a alpha.
-  if (!(groupname[0] >= 'a' && groupname[0] <= 'z')) {
+  if (!isalpha(groupname[0])) {
     return 1;
   }
 
   // The rest characters can be only alpha, digit, dash or underscore.
   for (size_t i = 1; i < len; i++) {
-    if (!(groupname[i] >= 'a' && groupname[i] <= 'z') && !(groupname[i] >= '0' && groupname[i] <= '9') &&
-        groupname[i] != '-' && groupname[i] != '_') {
+    if (!isalnum(groupname[i]) && groupname[i] != '-' && groupname[i] != '_') {
       return 1;
     }
   }

--- a/stns_test.c
+++ b/stns_test.c
@@ -275,11 +275,11 @@ Test(username_validation, valid_usernames)
   cr_assert(is_valid_username("username") == 0);
   cr_assert(is_valid_username("user-name") == 0);
   cr_assert(is_valid_username("username1") == 0);
+  cr_assert(is_valid_username("Username") == 0);
 }
 
 Test(username_validation, invalid_usernames)
 {
-  cr_assert(is_valid_username("Username") == 1);  // contains uppercase
   cr_assert(is_valid_username("username!") == 1); // contains special char
   cr_assert(is_valid_username("1username") == 1); // starts with digit
   cr_assert(is_valid_username("") == 1);          // empty string
@@ -295,11 +295,11 @@ Test(groupname_validation, valid_groupnames)
   cr_assert(is_valid_groupname("groupname") == 0);
   cr_assert(is_valid_groupname("group-name") == 0);
   cr_assert(is_valid_groupname("groupname1") == 0);
+  cr_assert(is_valid_groupname("Groupname") == 0);
 }
 
 Test(groupname_validation, invalid_groupnames)
 {
-  cr_assert(is_valid_groupname("Groupname") == 1);  // contains uppercase
   cr_assert(is_valid_groupname("groupname!") == 1); // contains special char
   cr_assert(is_valid_groupname("1groupname") == 1); // starts with digit
   cr_assert(is_valid_groupname("") == 1);           // empty string


### PR DESCRIPTION
ユーザ名とグループ名に英大文字を許可します。
英大文字を許可するかどうかは私が調べた限りでは、実装やディレクトリビューションによって変わるようですが、POSIXで許可されている[^1]のと、STNSがサポートしているディストリビューションに置いては大文字を使用できそうなので、大文字を許可しても問題ないと考えます。

```
❯ docker run -it --rm centos:7 bash -c "useradd User; id -a User"
uid=1000(User) gid=1000(User) groups=1000(User)

❯ docker run -it --rm debian:buster bash -c "useradd User; id -a User"
uid=1000(User) gid=1000(User) groups=1000(User)

❯ docker run -it --rm ubuntu:focal bash -c "useradd User; id -a User"
uid=1000(User) gid=1000(User) groups=1000(User)
```

参考:
* https://systemd.io/USER_NAMES/

[^1]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_282