### PR TITLE
fix: サーバ応答由来のバッファオーバーフロー/NULL参照を修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # The base of this code is https://github.com/pyama86/stns/blob/master/Makefile
 CC=gcc
-CFLAGS=-Os -Wall -Wstrict-prototypes -Werror -fPIC -std=c99 -D_GNU_SOURCE -I$(CURL_DIR)/include -I$(OPENSSL_DIR)/include
+CFLAGS=-Os -Wall -Wstrict-prototypes -Werror -fPIC -std=c99 -D_GNU_SOURCE -fstack-protector-strong -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -I$(CURL_DIR)/include -I$(OPENSSL_DIR)/include
 STNS_LDFLAGS=-Wl,--version-script,libstns.map
 
 LIBRARY=libnss_stns.so.2.0

--- a/stns.h
+++ b/stns.h
@@ -129,9 +129,9 @@ extern int is_valid_groupname(const char *username);
 #define STNS_SET_DEFAULT_VALUE(buf, name, def)                                                                         \
   char buf[MAXBUF];                                                                                                    \
   if (name != NULL && strnlen(name, STNS_MAX_BUFFER_SIZE) > 0) {                                                       \
-    strcpy(buf, name);                                                                                                 \
+    snprintf(buf, sizeof(buf), "%s", name);                                                                            \
   } else {                                                                                                             \
-    strcpy(buf, def);                                                                                                  \
+    snprintf(buf, sizeof(buf), "%s", def);                                                                             \
   }                                                                                                                    \
   name = buf;
 
@@ -166,14 +166,15 @@ extern int is_valid_groupname(const char *username);
   }
 
 #define SET_ATTRBUTE(type, name, attr)                                                                                 \
-  int name##_length = strnlen(name, STNS_MAX_BUFFER_SIZE) + 1;                                                         \
+  const char *name##_value = (name != NULL) ? name : "";                                                               \
+  int name##_length        = strnlen(name##_value, STNS_MAX_BUFFER_SIZE) + 1;                                          \
                                                                                                                        \
   if (buflen < name##_length) {                                                                                        \
     *errnop = ERANGE;                                                                                                  \
     return NSS_STATUS_TRYAGAIN;                                                                                        \
   }                                                                                                                    \
                                                                                                                        \
-  strcpy(buf, name);                                                                                                   \
+  strncpy(buf, name##_value, name##_length);                                                                           \
   rbuf->type##_##attr = buf;                                                                                           \
   buf += name##_length;                                                                                                \
   buflen -= name##_length;

--- a/stns_key_wrapper.c
+++ b/stns_key_wrapper.c
@@ -59,7 +59,7 @@ int main(int argc, char *argv[])
     return -1;
   }
 
-  int i;
+  int i, j;
   int size = 0;
   int key_size;
   JSON_Object *leaf;
@@ -80,47 +80,48 @@ int main(int argc, char *argv[])
     }
 
     JSON_Array *json_keys = json_object_get_array(leaf, "keys");
-    for (i = 0; i < json_array_get_count(json_keys); i++) {
-      const char *key = json_array_get_string(json_keys, i);
-
-      if (size != 0) {
-        keys[size] = '\n';
-        size++;
-        keys[size] = '\0';
+    for (j = 0; j < json_array_get_count(json_keys); j++) {
+      const char *key = json_array_get_string(json_keys, j);
+      if (key == NULL) {
+        continue;
       }
       key_size = strnlen(key, STNS_MAX_BUFFER_SIZE);
 
-      if (keys) {
-        keys = (char *)realloc(keys, key_size + strnlen(keys, STNS_MAX_BUFFER_SIZE) + 2);
-      } else {
-        keys = (char *)malloc(strnlen(key, STNS_MAX_BUFFER_SIZE) + 2);
+      // size(existing) + key + separator '\n' + terminator '\0'
+      char *resized = (char *)realloc(keys, size + key_size + 2);
+      if (resized == NULL) {
+        break;
       }
+      keys = resized;
 
       memcpy(&(keys[size]), key, (size_t)key_size);
       size += key_size;
+      keys[size] = '\n';
+      size++;
+      keys[size] = '\0';
     }
-  }
-
-  if (keys) {
-    keys[size] = '\n';
-    size++;
-    keys[size] = '\0';
   }
 
   if (c.chain_ssh_wrapper != NULL) {
     stns_response_t cr;
     cr.data = (char *)malloc(STNS_DEFAULT_BUFFER_SIZE);
-    if (stns_exec_cmd(c.chain_ssh_wrapper, argv[optind], &cr) == 0) {
-      key_size = cr.size;
-      keys     = (char *)realloc(keys, key_size + strnlen(keys, STNS_MAX_BUFFER_SIZE) + 1);
-      int len  = strnlen(cr.data, STNS_MAX_BUFFER_SIZE);
-      strncpy(&(keys[size]), cr.data, len + 1);
-      size += key_size;
+    if (cr.data != NULL && stns_exec_cmd(c.chain_ssh_wrapper, argv[optind], &cr) == 0) {
+      int len       = strnlen(cr.data, STNS_MAX_BUFFER_SIZE);
+      char *resized = (char *)realloc(keys, size + len + 1);
+      if (resized != NULL) {
+        keys = resized;
+        strncpy(&(keys[size]), cr.data, len + 1);
+        size += len;
+      }
     }
     free(cr.data);
   }
 
-  fprintf(stdout, "%s\n", keys);
+  if (keys != NULL) {
+    fprintf(stdout, "%s\n", keys);
+  } else {
+    fprintf(stdout, "\n");
+  }
   free(keys);
   json_value_free(root);
   stns_unload_config(&c);

--- a/stns_passwd_test.c
+++ b/stns_passwd_test.c
@@ -191,3 +191,40 @@ Test(inner_nss_stns_getpwent_r, ok)
   _nss_stns_endpwent();
   free(json);
 }
+
+Test(ensure_passwd_by_name, long_shell_no_overflow)
+{
+  struct passwd pwd;
+  char buffer[MAXBUF * 8];
+  stns_conf_t c;
+  c.uid_shift = 0;
+  c.gid_shift = 0;
+
+  // a shell longer than MAXBUF must not overflow the fixed stack buffer
+  char long_shell[4096];
+  memset(long_shell, 'a', sizeof(long_shell) - 1);
+  long_shell[sizeof(long_shell) - 1] = '\0';
+
+  char json[8192];
+  snprintf(json, sizeof(json), "[{\"id\":1,\"name\":\"user1\",\"group_id\":1,\"gecos\":\"test\",\"shell\":\"%s\"}]",
+           long_shell);
+
+  int code = ensure_passwd_by_name(json, &c, "user1", &pwd, buffer, sizeof(buffer), 0);
+  cr_assert_eq(code, NSS_STATUS_SUCCESS);
+  cr_assert(strnlen(pwd.pw_shell, sizeof(long_shell)) < MAXBUF);
+}
+
+Test(ensure_passwd_by_name, missing_gecos_no_crash)
+{
+  struct passwd pwd;
+  char buffer[MAXBUF];
+  stns_conf_t c;
+  c.uid_shift = 0;
+  c.gid_shift = 0;
+
+  // a missing gecos field must not crash (NULL is treated as "")
+  char *json = "[{\"id\":1,\"name\":\"user1\",\"group_id\":1,\"shell\":\"/bin/sh\"}]";
+  int code   = ensure_passwd_by_name(json, &c, "user1", &pwd, buffer, sizeof(buffer), 0);
+  cr_assert_eq(code, NSS_STATUS_SUCCESS);
+  cr_assert_str_eq(pwd.pw_gecos, "");
+}

--- a/stns_shadow_test.c
+++ b/stns_shadow_test.c
@@ -143,3 +143,23 @@ Test(inner_nss_stns_getspent_r, ok)
   _nss_stns_endspent();
   free(json);
 }
+
+Test(ensure_spwd_by_name, long_password_no_overflow)
+{
+  struct spwd spbuf;
+  char buffer[MAXBUF * 8];
+  stns_conf_t c;
+  c.uid_shift = 0;
+
+  // a password longer than MAXBUF must not overflow the fixed stack buffer
+  char long_password[4096];
+  memset(long_password, 'a', sizeof(long_password) - 1);
+  long_password[sizeof(long_password) - 1] = '\0';
+
+  char json[8192];
+  snprintf(json, sizeof(json), "[{\"id\":1,\"name\":\"user1\",\"password\":\"%s\"}]", long_password);
+
+  int code = ensure_spwd_by_name(json, &c, "user1", &spbuf, buffer, sizeof(buffer), 0);
+  cr_assert_eq(code, NSS_STATUS_SUCCESS);
+  cr_assert(strnlen(spbuf.sp_pwdp, sizeof(long_password)) < MAXBUF);
+}


### PR DESCRIPTION
## 概要
セキュリティレビューで発見した、**STNSサーバ応答を信頼することに起因するメモリ安全性の問題**を修正します。

NSSモジュール(`libnss_stns.so`)とSSH鍵ラッパー(`stns-key-wrapper`)は `sshd`/`login`/`sudo`/`cron` 等の**特権プロセス(多くはroot)にロード**され、改竄され得る入力(サーバ侵害・MITM・`ssl_verify=false`・平文HTTP・ローカル`cache-stnsd`経由)を処理します。応答値の長さ・NULLを検証していなかったため、特権プロセスのメモリ破壊につながり得ました。

## 修正内容

### 🔴 Critical: スタックバッファオーバーフロー (`stns.h` STNS_SET_DEFAULT_VALUE)
サーバ応答の `shell`/`directory`/`password` を固定長 `char[MAXBUF]`(1024) へ `strcpy` していたため、1024バイト超でスタックを破壊。
→ `snprintf(buf, sizeof(buf), ...)` で境界制限。

### 🟠 High1: NULL参照によるDoS (`stns.h` SET_ATTRBUTE)
`gecos`/`name` がNULL(応答にフィールド欠落時)でも未チェックで `strnlen`/`strcpy` していてクラッシュ。
→ NULLを `""` として扱う。

### 🟠 High2: 鍵連結ロジックのメモリ不具合 (`stns_key_wrapper.c`)
- 内側/外側ループで同じ変数 `i` を使用していた → `j` に分離
- `key` のNULLチェック追加
- `realloc` 戻り値チェック追加
- バッファサイズを `strnlen(keys)` ではなく追跡中の `size` で計算(NUL未終端時のヒープオーバーリード回避)
- `keys` がNULLのままの出力をガード

### ビルド緩和策 (`Makefile`)
`CFLAGS` に `-fstack-protector-strong -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2` を追加。

## テスト
- `stns_passwd_test.c`: 長い`shell`でスタックを破壊しないこと / `gecos`欠落でクラッシュしないこと
- `stns_shadow_test.c`: 長い`password`でスタックを破壊しないこと

CIのASANビルド(`make test`)で境界違反を検出する設計です。
※ `stns_key_wrapper.c` はユニットテスト対象外のため integrationテスト/コードレビューで担保。

## レビューで検出した残課題(本PR対象外・別途検討)
- 設定ファイル `stns.conf` が644で配置され `auth_token`/`password` がworld-readable
- HTTPヘッダコールバックの堅牢性(`User-Highest-Id:`値なしで`trim(NULL)`、`strtok`の非スレッドセーフ)
- 応答累積サイズの上限なし(メモリ枯渇DoS)
- 固定ロックファイル `/var/tmp/.stns.lock` による名前解決DoS